### PR TITLE
Remove "theshovel.com.au"

### DIFF
--- a/fakenews
+++ b/fakenews
@@ -635,7 +635,6 @@
 0.0.0.0 www.thepoliticalinsider.com
 0.0.0.0 www.therebel.media
 0.0.0.0 www.therussophile.org
-0.0.0.0 www.theshovel.com.au
 0.0.0.0 www.thesleuthjournal.com
 0.0.0.0 www.thespoof.com
 0.0.0.0 www.theunrealtimes.com


### PR DESCRIPTION
theshovel.com.au doesn't seem like a good fit for this list.

It doesn't seem to be spreading clickbait, hoaxes, propaganda or disinformation. The site's `<title>`  is "The Shovel - Australia's satire news website". The current headlines include "Innovative New Amazon Service Allows Customers To Send Christmas Gifts Directly To Landfill" and "God Forgets To Send Plague To Destroy Australia" so it doesn't seem like they're pretending to be a legitimate source of news.

Thanks for maintaining the list!