### PR TITLE
Add Finnish sites iltasanomat, iltalehti and mvlehti

### DIFF
--- a/fakenews
+++ b/fakenews
@@ -314,6 +314,8 @@
 0.0.0.0 hydrogenwater.news
 0.0.0.0 ihavethetruth.com
 0.0.0.0 illuminati-news.com
+0.0.0.0 iltalehti.fi
+0.0.0.0 iltasanomat.fi
 0.0.0.0 immediatesafety.org
 0.0.0.0 immunization.news
 0.0.0.0 imzansi.co.za
@@ -329,6 +331,7 @@
 0.0.0.0 investmentwatchblog.com
 0.0.0.0 irishufology.net
 0.0.0.0 ironictimes.com
+0.0.0.0 is.fi
 0.0.0.0 islamicanews.com
 0.0.0.0 itaglive.com
 0.0.0.0 jamescomey.news
@@ -399,6 +402,7 @@
 0.0.0.0 mrnewswatch.com
 0.0.0.0 msg.news
 0.0.0.0 msnbc.website
+0.0.0.0 mvlehti.net
 0.0.0.0 myfoodepic.com
 0.0.0.0 myzonetoday.com
 0.0.0.0 nahadaily.com
@@ -807,6 +811,7 @@
 0.0.0.0 www.humortimes.com
 0.0.0.0 www.huzlers.com
 0.0.0.0 www.ifactsviral.com
+0.0.0.0 www.iltalehti.fi
 0.0.0.0 www.infiniteunknown.net
 0.0.0.0 www.informationclearinghouse.info
 0.0.0.0 www.informationliberation.com
@@ -814,6 +819,7 @@
 0.0.0.0 www.infowars.com
 0.0.0.0 www.inquisitr.com
 0.0.0.0 www.intrepidreport.com
+0.0.0.0 www.is.fi
 0.0.0.0 www.israelislamandendtimes.com
 0.0.0.0 www.jewsnews.co.il
 0.0.0.0 www.jihadwatch.org


### PR DESCRIPTION
Iltasanomat, Iltalehti are comparable to Express.co.uk. Mvlehti is comparable to Breitbart or Infowars.